### PR TITLE
Fix issues with confocor3 header

### DIFF
--- a/examples/correlation/plot_confocor3_two_ch_correlation.py
+++ b/examples/correlation/plot_confocor3_two_ch_correlation.py
@@ -116,6 +116,6 @@ plt.semilogx(
     label="Corr(2,2)"
 )
 
-plt.ylim(1.032, 1.050)
+plt.ylim(0.98, 1.30)
 plt.show()
 

--- a/include/TTTRHeader.h
+++ b/include/TTTRHeader.h
@@ -14,6 +14,8 @@
 #include <array>
 #include <memory>
 #include <numeric>
+#include <iostream>
+#include <iomanip> /* std::setfill */
 #include <fstream> /* ifstream */
 
 #include <any>

--- a/include/TTTRHeaderTypes.h
+++ b/include/TTTRHeaderTypes.h
@@ -145,9 +145,15 @@ typedef union cz_confocor3_settings{
     struct{
         char Ident[52];
         char dummy1[11];
-        unsigned channel        :8;
-        unsigned TagHead_Idx    :32;
-        unsigned sync_rate      :32;
+        unsigned channel               :8;
+        // 64 byte
+        uint32_t measure_id[4];  // 16
+        uint32_t measurement_position; // 8
+        uint32_t kinetic_index; // 8
+        uint32_t repetition_number; // 8
+        uint32_t frequency; // 8
+        char dummy2[32]; //32
+        // 64 + 64 byte
     } bits;
 } cz_confocor3_settings_t;
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "0.24.1"
+version = "0.24.2"
 name = "tttrlib"
 requires-python = ">=3.8"
 description = "Read, write & process time-tagged time-resolved (TTTR) data."

--- a/src/TTTRHeader.cpp
+++ b/src/TTTRHeader.cpp
@@ -152,22 +152,45 @@ size_t TTTRHeader::read_cz_confocor3_header(
     if(rewind) std::fseek(fpin, 0, SEEK_SET);
     cz_confocor3_settings_t rec;
     fread(&rec, sizeof(rec),1, fpin);
-    fseek(fpin, 68, 0);
-    float sync_rate;
-    fread(&sync_rate, sizeof(float), 1, fpin);
-    double mt_clk = 1. / (1000. * sync_rate);
+
+    float frequency_float = rec.bits.frequency;
+    double mt_clk = 1. / frequency_float;
+
+    // Convert each element to hexadecimal and concatenate them
+    std::stringstream ss;
+    for (int i = 0; i < 4; i++) {
+        ss << std::hex << std::setw(8) << std::setfill('0') << rec.bits.measure_id[i];
+    }
+    size_t total_length = ss.str.length() + 1;
+    char* hex_measure_id = new char[total_length];
+    std::strcpy(hex_measure_id, ss.str().c_str());
+
+    int measurement_position = rec.bits.measurement_position;
+    int kinetic_index = rec.bits.kinetic_index;
+    int repetition_number = rec.bits.repetition_number;
+    int channel_nbr = rec.bits.channel - 48;
 
     add_tag(data, TTTRTagGlobRes, mt_clk, tyFloat8);
     // Convert ASCII channel number to int
-    add_tag(data, "channel", rec.bits.channel - 48, tyInt8);
-    add_tag(data, TTTRTagBits, 32, tyInt8);
     add_tag(data, TTTRRecordType, (int) CZ_RECORD_TYPE_CONFOCOR3, tyInt8);
+    add_tag(data, "channel", channel_nbr, tyInt8);
+    add_tag(data, "measure_id", hex_measure_id, tyAnsiString);
+    add_tag(data, "measurement_position", measurement_position + 1, tyInt8);
+    add_tag(data, "kinetic_index", kinetic_index + 1, tyInt8);
+    add_tag(data, "repetition_number", repetition_number + 1, tyInt8);
+    add_tag(data, TTTRTagBits, 32, tyInt8);
 #ifdef VERBOSE_TTTRLIB
     std::clog << "-- Confocor3 header reader " << std::endl;
+    std::clog << "-- frequency_float: " << frequency_float << std::endl;
+    std::clog << "-- measure_id_string: " << hex_measure_id << std::endl;
     std::clog << "-- macro_time_resolution: " << mt_clk << std::endl;
-    std::clog << "-- macro_time_resolution: " << sync_rate << std::endl;
+    std::clog << "-- channel_nbr: " << channel_nbr << std::endl;
+    std::clog << "-- measurement_position: " << measurement_position << std::endl;
+    std::clog << "-- kinetic_index: " << kinetic_index << std::endl;
+    std::clog << "-- repetition_number: " << repetition_number << std::endl;
+    std::clog << "-- header bytes: " << sizeof(rec) << std::endl;
 #endif
-    return 80;
+    return sizeof(rec);
 }
 
 

--- a/src/TTTRHeader.cpp
+++ b/src/TTTRHeader.cpp
@@ -161,7 +161,7 @@ size_t TTTRHeader::read_cz_confocor3_header(
     for (int i = 0; i < 4; i++) {
         ss << std::hex << std::setw(8) << std::setfill('0') << rec.bits.measure_id[i];
     }
-    size_t total_length = ss.str.length() + 1;
+    size_t total_length = ss.str().length() + 1;
     char* hex_measure_id = new char[total_length];
     std::strcpy(hex_measure_id, ss.str().c_str());
 

--- a/src/TTTRRecordReader.cpp
+++ b/src/TTTRRecordReader.cpp
@@ -291,30 +291,27 @@ bool ProcessSPC600_256(
         ){
     bh_spc600_256_record_t rec;
     rec.allbits = TTTRRecord;
-
     if(!rec.bits.mtov && !rec.bits.invalid){
         // normal record
         true_nsync = rec.bits.mt + overflow_counter * 4096;
         micro_time = (uint16_t) (255 - rec.bits.adc);
         channel = (uint16_t) (rec.bits.rout);
         return true;
-    } else{
-        if(!rec.bits.invalid && rec.bits.mtov){
-            // valid record with a single macro time overflow
-            overflow_counter += 1;
-            true_nsync = rec.bits.mt + overflow_counter * 65536; // 65536 = 2**16 (16 bits for macro time counter)
-            micro_time = (uint16_t) (255 - rec.bits.adc);
-            channel = (uint16_t) (rec.bits.rout);
-            return true;
-        } else{
-            if(rec.bits.invalid && rec.bits.mtov){
-                bh_overflow_t ovf;
-                ovf.allbits = TTTRRecord;
-                overflow_counter += ovf.bits.cnt;
-                return false;
-            }
-        }
     }
+    if(!rec.bits.invalid && rec.bits.mtov){
+        // valid record with a single macro time overflow
+        overflow_counter += 1;
+        true_nsync = rec.bits.mt + overflow_counter * 65536; // 65536 = 2**16 (16 bits for macro time counter)
+        micro_time = (uint16_t) (255 - rec.bits.adc);
+        channel = (uint16_t) (rec.bits.rout);
+        return true;
+    }
+    if(rec.bits.invalid && rec.bits.mtov){
+            bh_overflow_t ovf;
+            ovf.allbits = TTTRRecord;
+            overflow_counter += ovf.bits.cnt;
+            return false;
+        }
     return false;
 }
 


### PR DESCRIPTION
There was an issue with confocor3 header. The macro time calibration was 
not being read correctly. The changes mitigate this issue and add additional
functionality (read additional information from the header).