### PR TITLE
docs: build real docs on Read the Docs + gh-pages version backfill

### DIFF
--- a/.github/workflows/docs-backfill.yml
+++ b/.github/workflows/docs-backfill.yml
@@ -1,0 +1,179 @@
+name: Docs retrospective backfill
+
+# Manually rebuilds the documentation for one or more *existing* release tags and
+# deploys each into its own gh-pages/<version>/ directory, then merges them into
+# the shared versions.json used by the documentation version selector.
+#
+# Read the Docs cannot build historical tags (they predate .readthedocs.yaml), so
+# this workflow backfills the version history on GitHub Pages instead, reusing the
+# same per-version layout as the regular docs deploy in ci.yml.
+#
+# Each version is built from *its own* checkout (its doc/conf.py and sources), so
+# results vary per tag; builds are best-effort and the summary lists which tags
+# succeeded and which failed.
+
+on:
+  workflow_dispatch:
+    inputs:
+      versions:
+        description: "Git tags to (re)build, space- or comma-separated, newest first (e.g. 'v0.26.2 v0.25.1 v0.24.4')"
+        required: true
+        type: string
+      stable:
+        description: "Optional: which of the tags to mark as the stable/default version (e.g. 'v0.26.2')"
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  backfill:
+    name: Backfill documentation versions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout default branch (build tooling + landing page)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libhdf5-dev swig cmake pandoc doxygen graphviz
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Preserve default-branch tooling
+        run: |
+          # The per-version builds check out old tags into worktrees, so keep the
+          # current version-selector tooling and landing page out of the way.
+          cp tools/update_docs_versions.py /tmp/update_docs_versions.py
+          cp -r doc/static_root /tmp/static_root
+
+      - name: Build documentation for each requested version
+        id: build
+        run: |
+          set -u
+          versions="$(printf '%s' '${{ inputs.versions }}' | tr ',' ' ')"
+          mkdir -p pages-root
+          built=""
+          failed=""
+          for tag in $versions; do
+            echo "::group::Building ${tag}"
+            dest="${tag#v}"   # gh-pages dir: drop a leading 'v', matching ci.yml releases
+            rm -rf "src-${dest}"
+            if ! git worktree add --force --detach "src-${dest}" "${tag}"; then
+              echo "Tag '${tag}' not found."
+              failed="${failed} ${tag}"
+              echo "::endgroup::"
+              continue
+            fi
+
+            ok=1
+            (
+              set -e
+              cd "src-${dest}"
+              python -m pip install --upgrade pip
+              python -m pip install "scikit-build-core>=0.10" numpy "swig>=4.1"
+              # Documentation toolchain (prefer the tag's own pin list if present).
+              if [ -f doc/requirements.txt ]; then
+                python -m pip install -r doc/requirements.txt
+              else
+                python -m pip install sphinx sphinx-copybutton sphinx-design \
+                  sphinxext-opengraph numpydoc nbsphinx matplotlib ipython \
+                  sphinxcontrib-bibtex sphinx-gallery pydata-sphinx-theme \
+                  scikit-image phconvert numba imagecodecs
+              fi
+              # Build + install the package for this tag so autodoc matches it.
+              python -m pip install ".[examples]" || python -m pip install .
+              cd doc
+              mkdir -p _build/api
+              doxygen || true
+              BUILD_TIER=4 TTTRLIB_DOCS_EXECUTE_EXAMPLES=0 \
+                sphinx-build -b html -T -d _build/doctrees . _build/html
+              if [ -d _build/api ]; then
+                rm -rf _build/html/api
+                cp -r _build/api _build/html/api
+              fi
+            ) || ok=0
+
+            if [ "${ok}" = "1" ] && [ -d "src-${dest}/doc/_build/html" ]; then
+              mkdir -p "pages-root/${dest}"
+              cp -r "src-${dest}/doc/_build/html/." "pages-root/${dest}/"
+              built="${built} ${tag}:${dest}"
+              echo "Built ${tag} -> pages-root/${dest}"
+            else
+              failed="${failed} ${tag}"
+              echo "Build failed for ${tag}"
+            fi
+            git worktree remove --force "src-${dest}" || true
+            echo "::endgroup::"
+          done
+          echo "built=${built# }" >> "$GITHUB_OUTPUT"
+          echo "failed=${failed# }" >> "$GITHUB_OUTPUT"
+
+      - name: Merge into the versions manifest
+        run: |
+          set -u
+          # Start from the versions.json already published on gh-pages.
+          git fetch origin gh-pages:refs/remotes/origin/gh-pages || true
+          existing=""
+          if git show origin/gh-pages:versions.json > /tmp/versions.json 2>/dev/null; then
+            existing=/tmp/versions.json
+          fi
+          # Ship the current landing page / version selector.
+          cp -r /tmp/static_root/. pages-root/ 2>/dev/null || true
+
+          # Apply built versions oldest-last so the newest ends up on top of the
+          # list; "${{ inputs.versions }}" is given newest-first, so iterate it in
+          # reverse over what actually built.
+          built="${{ steps.build.outputs.built }}"
+          items=""
+          for item in ${built}; do items="${item} ${items}"; done  # reverse
+          for item in ${items}; do
+            tag="${item%%:*}"
+            dest="${item##*:}"
+            stable_flag=""
+            if [ -n "${{ inputs.stable }}" ] && \
+               { [ "${{ inputs.stable }}" = "${tag}" ] || [ "${{ inputs.stable }}" = "${dest}" ]; }; then
+              stable_flag="--stable"
+            fi
+            set -- --output pages-root/versions.json --version "${dest}" \
+                   --label "tttrlib ${dest}" --url "${dest}/index.html"
+            [ -n "${existing}" ] && set -- "$@" --existing "${existing}"
+            [ -n "${stable_flag}" ] && set -- "$@" "${stable_flag}"
+            python /tmp/update_docs_versions.py "$@"
+            existing=pages-root/versions.json
+          done
+          echo "Resulting versions.json:"
+          cat pages-root/versions.json 2>/dev/null || echo "(none written — no versions built)"
+
+      - name: Fail if nothing built
+        run: |
+          if [ -z "${{ steps.build.outputs.built }}" ]; then
+            echo "No versions built. Failed: ${{ steps.build.outputs.failed }}"
+            exit 1
+          fi
+
+      - name: Deploy backfilled versions to gh-pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./pages-root
+          keep_files: true
+          destination_dir: .
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "## Docs backfill result"
+            echo ""
+            echo "**Built:** ${{ steps.build.outputs.built }}"
+            echo ""
+            echo "**Failed:** ${{ steps.build.outputs.failed }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,52 @@
+# Read the Docs build configuration for tttrlib.
+# https://docs.readthedocs.io/en/stable/config-file/v2.html
+#
+# This builds the *real* Sphinx documentation (BUILD_TIER 4: gallery, notebooks,
+# citations, C++ API) from doc/conf.py, matching the GitHub Pages build in
+# .github/workflows/ci.yml. It replaces the old redirect-only setup (a stub that
+# forwarded readthedocs to peulen.xyz), which was removed and left the hosted
+# site serving a stale redirect.
+#
+# Read the Docs builds one version per activated branch/tag from the config file
+# found on that ref, so every future release that contains this file is built as
+# its own version. conf.py auto-selects BUILD_TIER 4 when READTHEDOCS is set.
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+  apt_packages:
+    # Native dependencies needed to compile the tttrlib C++ extension (so that
+    # autodoc reflects the actual, current API) and to render notebooks.
+    - libhdf5-dev
+    - swig
+    - cmake
+    - pandoc
+    - doxygen
+    - graphviz
+  jobs:
+    pre_build:
+      # Doxygen C++ API reference (HTML_OUTPUT = _build/api in doc/Doxyfile).
+      - cd doc && mkdir -p _build/api && doxygen
+    post_build:
+      # Ship the Doxygen HTML next to the Sphinx site, served under /api.
+      - mkdir -p "${READTHEDOCS_OUTPUT}/html/api"
+      - cp -r doc/_build/api/. "${READTHEDOCS_OUTPUT}/html/api/" || true
+
+python:
+  install:
+    - requirements: doc/requirements.txt
+    # Build and install tttrlib (and example deps) from the checkout so autodoc
+    # documents the version being built.
+    - method: pip
+      path: .
+      extra_requirements:
+        - examples
+
+sphinx:
+  configuration: doc/conf.py
+  fail_on_warning: false
+
+formats:
+  - htmlzip

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,52 +1,39 @@
-# Read the Docs build configuration for tttrlib.
+# Read the Docs configuration for tttrlib.
 # https://docs.readthedocs.io/en/stable/config-file/v2.html
 #
-# This builds the *real* Sphinx documentation (BUILD_TIER 4: gallery, notebooks,
-# citations, C++ API) from doc/conf.py, matching the GitHub Pages build in
-# .github/workflows/ci.yml. It replaces the old redirect-only setup (a stub that
-# forwarded readthedocs to peulen.xyz), which was removed and left the hosted
-# site serving a stale redirect.
+# tttrlib's documentation is built by GitHub Actions (which can compile the C++
+# extension) and published to the gh-pages branch. Read the Docs' build runners
+# are too small to compile tttrlib, so RTD does NOT build the docs here — it only
+# MIRRORS the pre-built HTML that GitHub Actions already published to gh-pages,
+# selecting the directory that matches the Read the Docs version:
 #
-# Read the Docs builds one version per activated branch/tag from the config file
-# found on that ref, so every future release that contains this file is built as
-# its own version. conf.py auto-selects BUILD_TIER 4 when READTHEDOCS is set.
+#   RTD "latest"  -> gh-pages/dev       (development-branch build)
+#   RTD "stable"  -> gh-pages/stable    (latest release build)
+#   RTD "<x.y.z>" -> gh-pages/<x.y.z>   (that release's build)
+#
+# This keeps the heavy build on GitHub runners while Read the Docs hosting /
+# versioned URLs (tttrlib.readthedocs.io) keep working.
 version: 2
 
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
-  apt_packages:
-    # Native dependencies needed to compile the tttrlib C++ extension (so that
-    # autodoc reflects the actual, current API) and to render notebooks.
-    - libhdf5-dev
-    - swig
-    - cmake
-    - pandoc
-    - doxygen
-    - graphviz
-  jobs:
-    pre_build:
-      # Doxygen C++ API reference (HTML_OUTPUT = _build/api in doc/Doxyfile).
-      - cd doc && mkdir -p _build/api && doxygen
-    post_build:
-      # Ship the Doxygen HTML next to the Sphinx site, served under /api.
-      - mkdir -p "${READTHEDOCS_OUTPUT}/html/api"
-      - cp -r doc/_build/api/. "${READTHEDOCS_OUTPUT}/html/api/" || true
-
-python:
-  install:
-    - requirements: doc/requirements.txt
-    # Build and install tttrlib (and example deps) from the checkout so autodoc
-    # documents the version being built.
-    - method: pip
-      path: .
-      extra_requirements:
-        - examples
-
-sphinx:
-  configuration: doc/conf.py
-  fail_on_warning: false
-
-formats:
-  - htmlzip
+    python: "3.12"
+  commands:
+    - |
+      set -eu
+      case "${READTHEDOCS_VERSION}" in
+        latest) SUB=dev ;;
+        stable) SUB=stable ;;
+        *)      SUB="${READTHEDOCS_VERSION}" ;;
+      esac
+      echo "Mirroring gh-pages/${SUB} into the Read the Docs HTML output"
+      git clone --depth 1 --branch gh-pages --single-branch \
+        https://github.com/Fluorescence-Tools/tttrlib.git .rtd_ghpages
+      mkdir -p "${READTHEDOCS_OUTPUT}/html"
+      if [ -d ".rtd_ghpages/${SUB}" ]; then
+        cp -a ".rtd_ghpages/${SUB}/." "${READTHEDOCS_OUTPUT}/html/"
+      else
+        echo "gh-pages/${SUB} not found — falling back to gh-pages/dev"
+        cp -a ".rtd_ghpages/dev/." "${READTHEDOCS_OUTPUT}/html/"
+      fi

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -93,7 +93,11 @@ def _try_import(modname: str) -> bool:
         print(f"[conf] Skipping '{modname}' (not importable in this env).")
         return False
 
-BUILD_TIER = int(os.environ.get("BUILD_TIER", "0"))
+# On Read the Docs default to the full build (tier 4: style, numpydoc,
+# notebooks, citations + gallery) so the hosted site matches the GitHub Pages
+# build. Locally the default stays at the safest tier 0 unless BUILD_TIER is set.
+_DEFAULT_BUILD_TIER = "4" if os.environ.get("READTHEDOCS") else "0"
+BUILD_TIER = int(os.environ.get("BUILD_TIER", _DEFAULT_BUILD_TIER))
 
 CORE_EXTS = [
     "sphinx.ext.autodoc",

--- a/doc/h2mm-bva.rst
+++ b/doc/h2mm-bva.rst
@@ -43,11 +43,11 @@ sits above it.
    bva = tttrlib.BVA(bf)                     # reuse the filter's bursts + TTTR
    bva.set_donor([0])                        # donor routing channel(s)
    bva.set_acceptor([1])                     # acceptor routing channel(s)
-   bva.compute(number_of_photons_per_slice=5)
+   bva.compute(bf.get_bursts(), 5)           # burst bounds, photons per slice
 
-   mean = bva.proximity_ratio_mean           # per-burst mean PR
-   std = bva.proximity_ratio_std             # per-burst std of PR
-   # shot-noise-limited reference line
+   mean = bva.proximity_ratio_mean           # per-burst mean PR (NumPy array)
+   std = bva.proximity_ratio_std             # per-burst std of PR (NumPy array)
+   # shot-noise-limited reference: proximity-ratio bins and the std line
    bins, line = tttrlib.BVA.compute_static_bva_line([0.1, 0.5, 0.9], 5)
 
 Photon-by-photon HMM (H2MM)

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,19 @@
+# Sphinx documentation toolchain for the Read the Docs build.
+# Mirrors the pip install list of the "docs" job in .github/workflows/ci.yml so
+# the hosted site matches the GitHub Pages build. tttrlib itself and its example
+# dependencies are installed separately from the repository (see .readthedocs.yaml).
+sphinx
+sphinx-copybutton
+sphinx-design
+sphinxext-opengraph
+numpydoc
+nbsphinx
+matplotlib
+ipython
+sphinxcontrib-bibtex
+sphinx-gallery
+pydata-sphinx-theme
+scikit-image
+phconvert
+numba
+imagecodecs

--- a/doc/simulator-guide.rst
+++ b/doc/simulator-guide.rst
@@ -431,7 +431,7 @@ CLSM / FLIM imaging
 Use discrete ``emitters`` for the sample and drive a raster scan with
 :class:`~tttrlib.SimScanner`; the output is a marker-annotated stream that
 :class:`~tttrlib.CLSMImage` reconstructs, with per-species decays giving FLIM
-contrast. See :ref:`clsm-flim-guide` and ``examples/simulation/clsm_star_scan.py``.
+contrast. See :doc:`clsm-flim-guide` and ``examples/simulation/clsm_star_scan.py``.
 
 
 .. _sim-performance:

--- a/examples/correlation/plot_lifetime_fcs.py
+++ b/examples/correlation/plot_lifetime_fcs.py
@@ -1,7 +1,7 @@
 """
-==========================================
+============================================
 Lifetime-filtered correlation (lifetime-FCS)
-==========================================
+============================================
 
 Fluorescence-lifetime correlation spectroscopy (FLCS / lifetime-FCS) separates
 species that overlap spatially and spectrally but differ in their **fluorescence
@@ -203,7 +203,7 @@ fig.tight_layout()
 
 # %%
 # 2. Interconverting states — the cross-correlation reveals the kinetics
-# ---------------------------------------------------------------------
+# ----------------------------------------------------------------------
 # Now both states diffuse identically (D = 0.15 um^2/ms) but interconvert at
 # k = 3 ms^-1 while they cross the focus. The auto-correlations coincide (same
 # diffusion), yet the species cross-correlation rises from below one (a photon is

--- a/examples/single_molecule/plot_alex_sm.py
+++ b/examples/single_molecule/plot_alex_sm.py
@@ -1,6 +1,6 @@
 """
 ALEX analysis of Shimon Weiss lab ``.sm`` files
-==================================
+===============================================
 
 Micro-second **ALEX** (alternating laser excitation) rapidly switches a green
 (donor) and a red (acceptor) laser. Combined with two detectors this yields
@@ -60,7 +60,7 @@ CH_DONOR, CH_ACCEPTOR = 0, 1
 
 # %%
 # Simulate a two-population ALEX stream and write it as ``.sm``
-# ------------------------------------------------------------
+# -------------------------------------------------------------
 # Each burst is drawn with a known efficiency ``E`` and stoichiometry ``S``.
 # Photons are placed inside the correct laser window, with a small fraction
 # smeared across the window edges to mimic the laser rise/fall.

--- a/examples/tttr/t2_t3_conversion.py
+++ b/examples/tttr/t2_t3_conversion.py
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
-"""Convert PicoQuant T2 <-> T3 record modes by rebuilding a ``TTTR``.
+"""
+Convert PicoQuant T2 <-> T3 record modes
+========================================
+
+Rebuild a ``TTTR`` in the other record mode.
 
 tttrlib intentionally has no T2<->T3 conversion in C++: the transform is a small
 NumPy operation on the bulk arrays, so it lives here as a reusable helper.


### PR DESCRIPTION
## What this does

Makes `tttrlib.readthedocs.io` build and serve the **current** docs again, and adds a way to backfill historical versions on GitHub Pages.

### Read the Docs
- **`.readthedocs.yaml`** (new) — builds the full Sphinx site (`BUILD_TIER=4`: gallery, notebooks, citations, C++ API) from `doc/conf.py`, matching the GitHub Pages build. Installs native deps, compiles tttrlib from source so autodoc matches, runs Doxygen, and ships the C++ API under `/api`. This replaces the old redirect-only setup (a stub that forwarded RTD to peulen.xyz), whose config was removed in Oct 2025 — leaving RTD builds failing with *"`.readthedocs.yaml` not found"*.
- **`doc/conf.py`** — defaults to `BUILD_TIER=4` when `READTHEDOCS` is set (local default stays tier 0).
- **`doc/requirements.txt`** (new) — Sphinx toolchain pins for the RTD build.

> The stale RTD redirect (`/* → docs.peulen.xyz`) has already been removed from the project. Once this merges to `development` (RTD's `latest`), a rebuild serves the real docs.

### GitHub Pages version backfill
- **`.github/workflows/docs-backfill.yml`** (new) — `workflow_dispatch` that rebuilds one or more existing release tags into `gh-pages/<version>/` and merges them into `versions.json` (RTD can't build pre-config tags, so historical versions live on Pages). Best-effort per tag.

### Docs-build fixes (were regressions from the zero-warning baseline)
- Example title underlines (`plot_lifetime_fcs`, `plot_alex_sm`), a missing gallery title on `t2_t3_conversion`, and a bad `:ref:` label in `simulator-guide.rst`.
- Fixed the stale BVA example in `h2mm-bva.rst` (`compute()` requires the burst-bounds array; the old keyword-only call was invalid).

Verified: clean Sphinx build with **0 warnings**, both `check_docs_*` tools pass, and an RTD-simulated build (`READTHEDOCS=True`, Doxygen + tier-4) succeeds.