### PR TITLE
docs(gallery): fix untitled correlation & beginner example galleries

### DIFF
--- a/examples/beginner/README.txt
+++ b/examples/beginner/README.txt
@@ -1,35 +1,12 @@
 .. _beginner_examples:
 
-# Beginner Examples for tttrlib
+Beginner Examples for tttrlib
+-----------------------------
 
-This directory contains small, runnable examples that mirror the tested core features of ``tttrlib``.
+Small, runnable examples that mirror the tested core features of ``tttrlib``.
 They are safe to copy-paste into your own analysis.
 
-Make sure the demo data bundle is available (see ``test/test_settings.py``) and set ``TTTRLIB_DATA`` accordingly.
-
-## Examples
-
-* ``plot_01_read_tttr.py``
-  Load a TTTR file (PTU), print basic info (macro/micro times, routing channels), and make first diagnostic plots.
-
-* ``plot_02_slice_join_append.py``
-  Take small slices, join/append photon streams, compare macro-time timelines (shifted vs unshifted), and get a micro-time histogram.
-
-* ``plot_03_selections_bursts_traces.py``
-  Do count-rate based LOW/HIGH selections, run burst search, build per-burst micro-time histograms (log scale), and plot 1 ms intensity traces (first 3 s) with burst regions shaded.
-
-* ``plot_04_write_convert.py``
-  Write subsets to a new file, make a full native copy, and convert between vendor formats by reusing a header template.
-
-* ``plot_05_clsm_zeiss980.py``
-  Reconstruct a confocal (CLSM) image from Zeiss LSM 980 TTTR data, show an intensity projection, and plot a per-pixel mean micro-time (pseudo-lifetime) map.
-
-## How to run
-
-From this directory:
-
-```````````````````````````
-python plot_01_read_tttr.py
-```````````````````````````
-
-Each script will either run and generate figures/output files, or exit with a clear message if the demo data cannot be found.
+Make sure the demo data bundle is available (see ``test/test_settings.py``) and
+set the ``TTTRLIB_DATA`` environment variable accordingly. Each script either
+runs and generates figures, or exits with a clear message when the demo data
+cannot be found.

--- a/examples/correlation/README.txt
+++ b/examples/correlation/README.txt
@@ -1,7 +1,7 @@
-
 .. _fcs_examples:
 
 Fluorescence correlation
- 
+------------------------
+
 Examples for computing auto-/cross-correlation functions from TTTR data,
 including gated, sliced, and normalized correlation variants.


### PR DESCRIPTION
The example gallery at `auto_examples/index.html` had broken sub-galleries:

- **`examples/correlation/README.txt`** — the title "Fluorescence correlation" had a lone space instead of an underline, so the whole correlation gallery rendered as `<no title>` and every correlation example breadcrumbed to it.
- **`examples/beginner/README.txt`** — written in Markdown; RST mis-parsed a `````` code fence into the gallery title ("python plot_01_read_tttr.py") and rendered the body as literal `##`/fence text.

Both are now valid reStructuredText with proper section titles. Verified with a clean tier-4 build: **0 warnings, 0 `<no title>`** across all galleries.

Neither emitted a Sphinx warning (an unrecognized title is silent), which is why they weren't caught earlier. Once merged and gh-pages redeploys, the RTD mirror picks it up on the next build.